### PR TITLE
Breaking: Replace integrationFn with onRequest

### DIFF
--- a/examples/with-koa/index.js
+++ b/examples/with-koa/index.js
@@ -31,11 +31,8 @@ app.use(
     playground: {
       path: '/playground',
     },
-    integrationFn: (ctx) => {
-      return {
-        request: ctx.req,
-        response: ctx.res,
-      };
+    onRequest: (args, done) => {
+      done(args[0].req);
     },
     onResonse: ({ headers, body, status }, ctx) => {
       ctx.status = status;

--- a/packages/graphyne-core/src/core.ts
+++ b/packages/graphyne-core/src/core.ts
@@ -171,7 +171,7 @@ export class GraphyneCore {
   ): void | Promise<void> {
     let compiledQuery: CompiledQuery | ExecutionResult;
 
-    const createResponse = (code: number, obj: ExecutionResult) => {
+    function createResponse(code: number, obj: ExecutionResult) {
       const payload = (compiledQuery && isCompiledQuery(compiledQuery)
         ? compiledQuery.stringify
         : fastStringify)(obj);
@@ -181,7 +181,7 @@ export class GraphyneCore {
         status: code,
         headers: { 'content-type': 'application/json' },
       });
-    };
+    }
 
     try {
       if (!query)

--- a/packages/graphyne-core/src/types.ts
+++ b/packages/graphyne-core/src/types.ts
@@ -1,10 +1,12 @@
 import { GraphQLError, GraphQLSchema, DocumentNode } from 'graphql';
 import { CompiledQuery } from 'graphql-jit';
 
-export interface Config<TContext = Record<string, any>, TRootValue = any> {
+export type TContext = Record<string, any>;
+
+export interface Config {
   schema: GraphQLSchema;
-  context?: TContext | ((...args: any[]) => TContext);
-  rootValue?: ((parsedQuery: DocumentNode) => TRootValue) | TRootValue;
+  context?: TContext | ((...args: any[]) => TContext | Promise<TContext>);
+  rootValue?: ((parsedQuery: DocumentNode) => any) | any;
   cache?: number | boolean;
 }
 

--- a/packages/graphyne-server/README.md
+++ b/packages/graphyne-server/README.md
@@ -78,7 +78,7 @@ A guide on how to integrate [dataloader](https://github.com/graphql/dataloader) 
 
 **Signature function** refers to framework-specific's handler function. For example, in `Express.js`, it is `(req, res, next)`. In `Hapi`, it is `(request, h)`. In `Micro` or `Node HTTP Server`, it is simply `(req, res)` just like `Node HTTP Server`.
 
-### How to work with frameworks with non-standard signature
+### Integrate with non-standard signature frameworks
 
 By default, `graphyne-server` expects the `Node HTTP Server` listener signature of `(req, res)`. However, as seen above, frameworks like Hapi or Koa does not follow the convention. In such cases `onRequest`, `onResponse`, and `onNoMatch` must be defined when calling `GraphyneServer#createHandler`.
 
@@ -94,11 +94,11 @@ In `koa`, however, the handler function has a signature of `(ctx, next)`, and th
 
 ```javascript
 graphyne.createHandler({
-    onRequest: ([ctx, next], done) => {
-      // ctx is the first argument in koa's signature function
-      // req is a property of ctx in koa (ctx.request is the flavored request object)
-      done(ctx.req);
-    },
+  onRequest: ([ctx, next], done) => {
+    // ctx is the first argument in koa's signature function
+    // req is a property of ctx in koa (ctx.request is the flavored request object)
+    done(ctx.req);
+  },
 })
 ```
 
@@ -116,28 +116,27 @@ In `koa`, however, not only that `response` is not the second argument, it has a
 
 ```javascript
 graphyne.createHandler({
-    onResponse: ({ headers, body, status }, ctx, next) => {
-      ctx.status = status;
-      ctx.set(headers);
-      ctx.body = body;
-    }
-  })
+  onResponse: ({ headers, body, status }, ctx, next) => {
+    ctx.status = status;
+    ctx.set(headers);
+    ctx.body = body;
+  }
+})
 ```
 
 `onNoMatch(result, ...args)`
 
-By default, `onNoMatch` would call `onResponse` with the `result = {status: 404, body:"not found", headers:{}}`.
+By default, `onNoMatch` would call `onResponse` with `result = {status: 404, body: "not found", headers: {}}`.
 
 If you configurate `onResponse` correctly for `koa` earlier. This will work just fine. However, let's define this function anyway to see how it will work for other frameworks. Similarly, the arguments of `onNoMatch` will be `(ctx, next)` (like `onResponse` without the `result` argument) so we can integrate like so:
 
 ```javascript
 graphyne.createHandler({
-    onNoMatch: (ctx, next) => {
-      ctx.status = 404;
-      ctx.set(headers);
-      ctx.body = body;
-    }
-  })
+  onNoMatch: (ctx, next) => {
+    ctx.status = 404;
+    ctx.body = 'not found';
+  }
+})
 ```
 
 ### Examples
@@ -203,17 +202,12 @@ fastify.use(
 app.use(
   graphyne.createHandler({
     onRequest: ([ctx, next], done) => {
-      // ctx is the first argument in koa's signature function
       done(ctx.req);
     },
     onResponse: ({ headers, body, status }, ctx) => {
       ctx.status = status;
       ctx.set(headers);
       ctx.body = body;
-    },
-    onNoMatch: (ctx) => {
-      ctx.status = 404;
-      ctx.body = 'not found';
     },
   })
 );

--- a/packages/graphyne-server/README.md
+++ b/packages/graphyne-server/README.md
@@ -239,7 +239,7 @@ exports.handler = graphyne.createHandler({
 
 #### Other frameworks
 
-As long as the framework exposes Node.js `IncomingMessage`, `graphyne-server` will work by configuring using `onRequest`, `onResponse`, and `onNoMatch`. If not, you can try to construct one by creating an object with `request.path`, `request.body`, `request.headers` and `request.method`.
+As long as the framework exposes Node.js `IncomingMessage`, `graphyne-server` will work by configuring using `onRequest`, `onResponse`, and `onNoMatch`. If not, you can try to construct one by creating an object with `request.url`, `request.body`, `request.headers`, `request.method`.
 
 My plan is to provide prepared config/presets within this package (perhaps by importing from `graphyne-server/integrations`). Yet, since Node.js ecosystem has a wide range of frameworks, it will be impossible to add one for each of them. If there is any framework you fail to integrate, feel free to create an issue.
 

--- a/packages/graphyne-server/package.json
+++ b/packages/graphyne-server/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@polka/url": "^1.0.0-next.11",
-    "graphyne-core": "^0.6.2"
+    "graphyne-core": "^0.6.2",
+    "reusify": "^1.0.4"
   },
   "devDependencies": {
     "@types/node": "^13.11.0"

--- a/packages/graphyne-server/package.json
+++ b/packages/graphyne-server/package.json
@@ -25,8 +25,7 @@
   },
   "dependencies": {
     "@polka/url": "^1.0.0-next.11",
-    "graphyne-core": "^0.6.2",
-    "reusify": "^1.0.4"
+    "graphyne-core": "^0.6.2"
   },
   "devDependencies": {
     "@types/node": "^13.11.0"

--- a/packages/graphyne-server/src/graphyneServer.ts
+++ b/packages/graphyne-server/src/graphyneServer.ts
@@ -17,10 +17,6 @@ import { HandlerConfig, ExtendedRequest } from './types';
 const sendresponse = (result: QueryResponse, res: ServerResponse) =>
   res.writeHead(result.status, result.headers).end(result.body);
 
-const onnomatch = (res: ServerResponse) => {
-  res.writeHead(404).end('not found');
-};
-
 const onrequest = (args: any[], done: (req: IncomingMessage) => void) =>
   done(args[0]);
 
@@ -58,7 +54,7 @@ export class GraphyneServer extends GraphyneCore {
           default:
             return options?.onNoMatch
               ? options.onNoMatch(...args)
-              : onnomatch(args[1]);
+              : sendResponse({ body: 'not found', status: 404, headers: {} });
         }
       }
 

--- a/packages/graphyne-server/src/graphyneServer.ts
+++ b/packages/graphyne-server/src/graphyneServer.ts
@@ -1,115 +1,18 @@
-import { RequestListener } from 'http';
+import { RequestListener, IncomingMessage, ServerResponse } from 'http';
 import {
   GraphyneCore,
   Config,
+  QueryResponse,
   renderPlayground,
   fastStringify,
+  QueryBody,
   TContext,
+  QueryRequest,
 } from 'graphyne-core';
+import { parseNodeRequest, getGraphQLParams } from './utils';
 // @ts-ignore
 import parseUrl from '@polka/url';
-// @ts-ignore
-import reusify from 'reusify';
-import { parseNodeRequest, getGraphQLParams } from './utils';
-import { HandlerConfig, HandlerInstance } from './types';
-
-var handlerInstance = reusify(Handler);
-
-function Handler(this: HandlerInstance) {
-  this.next = null;
-  this.args = [];
-
-  var that = this;
-
-  this.onRequestResolve = function (request) {
-    const path = that.options?.path || '/graphql';
-    const playgroundPath = that.options?.playground
-      ? (typeof that.options.playground === 'object' &&
-          that.options.playground.path) ||
-        '/playground'
-      : null;
-    switch (request.path || parseUrl(request, true).pathname) {
-      case path:
-        return parseNodeRequest(request, that.onBodyParsed);
-      case playgroundPath:
-        return that.sendResponse({
-          status: 200,
-          body: renderPlayground({
-            endpoint: path,
-            subscriptionEndpoint: that.subscriptionPath,
-          }),
-          headers: { 'content-type': 'text/html; charset=utf-8' },
-        });
-      default:
-        return that.options?.onNoMatch
-          ? that.options.onNoMatch(...that.args)
-          : that.sendResponse({ body: 'not found', status: 404, headers: {} });
-    }
-  };
-
-  this.onBodyParsed = function (parseErr, request, parsedBody) {
-    if (parseErr) return that.sendError(parseErr);
-    const params = getGraphQLParams({
-      queryParams: request.query || parseUrl(request, true).query || {},
-      body: parsedBody,
-    });
-    params.httpRequest = { method: request.method as string };
-    return that.onParamParsed(params);
-  };
-
-  this.onParamParsed = function (params) {
-    try {
-      const contextFn = that.graphyneOpt.context;
-      const context: TContext | Promise<TContext> =
-        typeof contextFn === 'function'
-          ? contextFn(...that.args)
-          : contextFn || {};
-      // FIXME: Types error
-      return 'then' in context
-        ? context.then(
-            (resolvedCtx: TContext) =>
-              that.onContextResolved(resolvedCtx, params),
-            (error: any) => {
-              error.message = `Context creation failed: ${error.message}`;
-              return that.sendError(error);
-            }
-          )
-        : that.onContextResolved(context, params);
-    } catch (error) {
-      error.message = `Context creation failed: ${error.message}`;
-      return that.sendError(error);
-    }
-  };
-
-  this.onContextResolved = function (context, params) {
-    that.runQuery(
-      {
-        query: params.query,
-        context,
-        variables: params.variables,
-        operationName: params.operationName,
-        httpRequest: {
-          method: params.httpRequest?.method as string,
-        },
-      },
-      that.sendResponse
-    );
-  };
-
-  this.sendResponse = function (result) {
-    if (that.options?.onResponse) that.options.onResponse(result, ...that.args);
-    else that.args[1].writeHead(result.status, result.headers).end(result.body);
-    handlerInstance.release(that);
-  };
-
-  this.sendError = function (error: any) {
-    return that.sendResponse({
-      status: error.status || 500,
-      body: fastStringify({ errors: [error] }),
-      headers: { 'content-type': 'application/json' },
-    });
-  };
-}
+import { HandlerConfig, ExtendedRequest } from './types';
 
 export class GraphyneServer extends GraphyneCore {
   constructor(options: Config) {
@@ -117,15 +20,109 @@ export class GraphyneServer extends GraphyneCore {
   }
 
   createHandler(options?: HandlerConfig): RequestListener | any {
+    const path = options?.path || '/graphql';
+    const playgroundPath = options?.playground
+      ? (typeof options.playground === 'object' && options.playground.path) ||
+        '/playground'
+      : null;
+
     return (...args: any[]) => {
-      const obj: HandlerInstance = handlerInstance.get();
-      obj.args = args;
-      obj.options = options;
-      obj.graphyneOpt = this.options;
-      obj.runQuery = this.runQuery.bind(this);
-      obj.subscriptionPath = this.subscriptionPath;
-      if (options?.onRequest) options.onRequest(args, obj.onRequestResolve);
-      else obj.onRequestResolve(args[0]);
+      const that = this;
+
+      if (options?.onRequest) options.onRequest(args, onRequestResolve);
+      else onRequestResolve(args[0]);
+
+      function onRequestResolve(request: ExtendedRequest) {
+        switch (request.path || parseUrl(request, true).pathname) {
+          case path:
+            return parseNodeRequest(request, onBodyParsed);
+          case playgroundPath:
+            return sendResponse({
+              status: 200,
+              body: renderPlayground({
+                endpoint: path,
+                subscriptionEndpoint: that.subscriptionPath,
+              }),
+              headers: { 'content-type': 'text/html; charset=utf-8' },
+            });
+          default:
+            return options?.onNoMatch
+              ? options.onNoMatch(...args)
+              : sendResponse({ body: 'not found', status: 404, headers: {} });
+        }
+      }
+
+      function onBodyParsed(
+        parseErr: any,
+        request: ExtendedRequest,
+        parsedBody?: QueryBody
+      ) {
+        if (parseErr) return sendError(parseErr);
+        const params = getGraphQLParams({
+          queryParams: request.query || parseUrl(request, true).query || {},
+          body: parsedBody,
+        });
+        params.httpRequest = { method: request.method as string };
+        return onParamParsed(params);
+      }
+
+      function onParamParsed(params: Partial<QueryRequest>) {
+        try {
+          const contextFn = that.options.context;
+          const context: TContext | Promise<TContext> =
+            typeof contextFn === 'function'
+              ? contextFn(...args)
+              : contextFn || {};
+          // FIXME: Types error
+          return 'then' in context
+            ? context.then(
+                (resolvedCtx: TContext) =>
+                  onContextResolved(resolvedCtx, params),
+                (error: any) => {
+                  error.message = `Context creation failed: ${error.message}`;
+                  return sendError(error);
+                }
+              )
+            : onContextResolved(context, params);
+        } catch (error) {
+          error.message = `Context creation failed: ${error.message}`;
+          return sendError(error);
+        }
+      }
+
+      function onContextResolved(
+        context: Record<string, any>,
+        params: Partial<QueryRequest>
+      ) {
+        that.runQuery(
+          {
+            query: params.query,
+            context,
+            variables: params.variables,
+            operationName: params.operationName,
+            httpRequest: {
+              method: params.httpRequest?.method as string,
+            },
+          },
+          sendResponse
+        );
+      }
+
+      function sendResponse(result: QueryResponse) {
+        if (options?.onResponse) return options.onResponse(result, ...args);
+        else
+          return args[1]
+            .writeHead(result.status, result.headers)
+            .end(result.body);
+      }
+
+      function sendError(error: any) {
+        return sendResponse({
+          status: error.status || 500,
+          body: fastStringify({ errors: [error] }),
+          headers: { 'content-type': 'application/json' },
+        });
+      }
     };
   }
 }

--- a/packages/graphyne-server/src/graphyneServer.ts
+++ b/packages/graphyne-server/src/graphyneServer.ts
@@ -1,18 +1,115 @@
-import { RequestListener, IncomingMessage, ServerResponse } from 'http';
+import { RequestListener } from 'http';
 import {
   GraphyneCore,
   Config,
-  QueryResponse,
   renderPlayground,
   fastStringify,
-  QueryBody,
   TContext,
-  QueryRequest,
 } from 'graphyne-core';
-import { parseNodeRequest, getGraphQLParams } from './utils';
 // @ts-ignore
 import parseUrl from '@polka/url';
-import { HandlerConfig, ExtendedRequest } from './types';
+// @ts-ignore
+import reusify from 'reusify';
+import { parseNodeRequest, getGraphQLParams } from './utils';
+import { HandlerConfig, HandlerInstance } from './types';
+
+var handlerInstance = reusify(Handler);
+
+function Handler(this: HandlerInstance) {
+  this.next = null;
+  this.args = [];
+
+  var that = this;
+
+  this.onRequestResolve = function (request) {
+    const path = that.options?.path || '/graphql';
+    const playgroundPath = that.options?.playground
+      ? (typeof that.options.playground === 'object' &&
+          that.options.playground.path) ||
+        '/playground'
+      : null;
+    switch (request.path || parseUrl(request, true).pathname) {
+      case path:
+        return parseNodeRequest(request, that.onBodyParsed);
+      case playgroundPath:
+        return that.sendResponse({
+          status: 200,
+          body: renderPlayground({
+            endpoint: path,
+            subscriptionEndpoint: that.subscriptionPath,
+          }),
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        });
+      default:
+        return that.options?.onNoMatch
+          ? that.options.onNoMatch(...that.args)
+          : that.sendResponse({ body: 'not found', status: 404, headers: {} });
+    }
+  };
+
+  this.onBodyParsed = function (parseErr, request, parsedBody) {
+    if (parseErr) return that.sendError(parseErr);
+    const params = getGraphQLParams({
+      queryParams: request.query || parseUrl(request, true).query || {},
+      body: parsedBody,
+    });
+    params.httpRequest = { method: request.method as string };
+    return that.onParamParsed(params);
+  };
+
+  this.onParamParsed = function (params) {
+    try {
+      const contextFn = that.graphyneOpt.context;
+      const context: TContext | Promise<TContext> =
+        typeof contextFn === 'function'
+          ? contextFn(...that.args)
+          : contextFn || {};
+      // FIXME: Types error
+      return 'then' in context
+        ? context.then(
+            (resolvedCtx: TContext) =>
+              that.onContextResolved(resolvedCtx, params),
+            (error: any) => {
+              error.message = `Context creation failed: ${error.message}`;
+              return that.sendError(error);
+            }
+          )
+        : that.onContextResolved(context, params);
+    } catch (error) {
+      error.message = `Context creation failed: ${error.message}`;
+      return that.sendError(error);
+    }
+  };
+
+  this.onContextResolved = function (context, params) {
+    that.runQuery(
+      {
+        query: params.query,
+        context,
+        variables: params.variables,
+        operationName: params.operationName,
+        httpRequest: {
+          method: params.httpRequest?.method as string,
+        },
+      },
+      that.sendResponse
+    );
+  };
+
+  this.sendResponse = function (result) {
+    if (that.options?.onResponse) that.options.onResponse(result, ...that.args);
+    else that.args[1].writeHead(result.status, result.headers).end(result.body);
+    handlerInstance.release(that);
+  };
+
+  this.sendError = function (error: any) {
+    return that.sendResponse({
+      status: error.status || 500,
+      body: fastStringify({ errors: [error] }),
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+}
 
 export class GraphyneServer extends GraphyneCore {
   constructor(options: Config) {
@@ -20,109 +117,15 @@ export class GraphyneServer extends GraphyneCore {
   }
 
   createHandler(options?: HandlerConfig): RequestListener | any {
-    const path = options?.path || '/graphql';
-    const playgroundPath = options?.playground
-      ? (typeof options.playground === 'object' && options.playground.path) ||
-        '/playground'
-      : null;
-
     return (...args: any[]) => {
-      const that = this;
-
-      if (options?.onRequest) options.onRequest(args, onRequestResolve);
-      else onRequestResolve(args[0]);
-
-      function onRequestResolve(request: ExtendedRequest) {
-        switch (request.path || parseUrl(request, true).pathname) {
-          case path:
-            return parseNodeRequest(request, onBodyParsed);
-          case playgroundPath:
-            return sendResponse({
-              status: 200,
-              body: renderPlayground({
-                endpoint: path,
-                subscriptionEndpoint: that.subscriptionPath,
-              }),
-              headers: { 'content-type': 'text/html; charset=utf-8' },
-            });
-          default:
-            return options?.onNoMatch
-              ? options.onNoMatch(...args)
-              : sendResponse({ body: 'not found', status: 404, headers: {} });
-        }
-      }
-
-      function onBodyParsed(
-        parseErr: any,
-        request: ExtendedRequest,
-        parsedBody?: QueryBody
-      ) {
-        if (parseErr) return sendError(parseErr);
-        const params = getGraphQLParams({
-          queryParams: request.query || parseUrl(request, true).query || {},
-          body: parsedBody,
-        });
-        params.httpRequest = { method: request.method as string };
-        return onParamParsed(params);
-      }
-
-      function onParamParsed(params: Partial<QueryRequest>) {
-        try {
-          const contextFn = that.options.context;
-          const context: TContext | Promise<TContext> =
-            typeof contextFn === 'function'
-              ? contextFn(...args)
-              : contextFn || {};
-          // FIXME: Types error
-          return 'then' in context
-            ? context.then(
-                (resolvedCtx: TContext) =>
-                  onContextResolved(resolvedCtx, params),
-                (error: any) => {
-                  error.message = `Context creation failed: ${error.message}`;
-                  return sendError(error);
-                }
-              )
-            : onContextResolved(context, params);
-        } catch (error) {
-          error.message = `Context creation failed: ${error.message}`;
-          return sendError(error);
-        }
-      }
-
-      function onContextResolved(
-        context: Record<string, any>,
-        params: Partial<QueryRequest>
-      ) {
-        that.runQuery(
-          {
-            query: params.query,
-            context,
-            variables: params.variables,
-            operationName: params.operationName,
-            httpRequest: {
-              method: params.httpRequest?.method as string,
-            },
-          },
-          sendResponse
-        );
-      }
-
-      function sendResponse(result: QueryResponse) {
-        if (options?.onResponse) return options.onResponse(result, ...args);
-        else
-          return args[1]
-            .writeHead(result.status, result.headers)
-            .end(result.body);
-      }
-
-      function sendError(error: any) {
-        return sendResponse({
-          status: error.status || 500,
-          body: fastStringify({ errors: [error] }),
-          headers: { 'content-type': 'application/json' },
-        });
-      }
+      const obj: HandlerInstance = handlerInstance.get();
+      obj.args = args;
+      obj.options = options;
+      obj.graphyneOpt = this.options;
+      obj.runQuery = this.runQuery.bind(this);
+      obj.subscriptionPath = this.subscriptionPath;
+      if (options?.onRequest) options.onRequest(args, obj.onRequestResolve);
+      else obj.onRequestResolve(args[0]);
     };
   }
 }

--- a/packages/graphyne-server/src/graphyneServer.ts
+++ b/packages/graphyne-server/src/graphyneServer.ts
@@ -1,4 +1,4 @@
-import { RequestListener, IncomingMessage, ServerResponse } from 'http';
+import { RequestListener } from 'http';
 import {
   GraphyneCore,
   Config,

--- a/packages/graphyne-server/src/graphyneServer.ts
+++ b/packages/graphyne-server/src/graphyneServer.ts
@@ -7,21 +7,22 @@ import {
   fastStringify,
   QueryBody,
   TContext,
+  QueryRequest,
 } from 'graphyne-core';
 import { parseNodeRequest, getGraphQLParams } from './utils';
 // @ts-ignore
 import parseUrl from '@polka/url';
-import { HandlerConfig } from './types';
+import { HandlerConfig, ExtendedRequest } from './types';
 
-const sendresponse = (
-  result: QueryResponse,
-  req: IncomingMessage,
-  res: ServerResponse
-) => res.writeHead(result.status, result.headers).end(result.body);
+const sendresponse = (result: QueryResponse, res: ServerResponse) =>
+  res.writeHead(result.status, result.headers).end(result.body);
 
 const onnomatch = (res: ServerResponse) => {
   res.writeHead(404).end('not found');
 };
+
+const onrequest = (args: any[], done: (req: IncomingMessage) => void) =>
+  done(args[0]);
 
 export class GraphyneServer extends GraphyneCore {
   constructor(options: Config) {
@@ -29,60 +30,53 @@ export class GraphyneServer extends GraphyneCore {
   }
 
   createHandler(options?: HandlerConfig): RequestListener | any {
+    const path = options?.path || '/graphql';
+    const playgroundPath = options?.playground
+      ? (typeof options.playground === 'object' && options.playground.path) ||
+        '/playground'
+      : null;
+
     return (...args: any[]) => {
       const that = this;
-      const path = options?.path || '/graphql';
-      const playgroundPath = options?.playground
-        ? (typeof options.playground === 'object' && options.playground.path) ||
-          '/playground'
-        : null;
 
-      let request: IncomingMessage & {
-          path?: string;
-          query?: Record<string, string>;
-        },
-        response: ServerResponse;
+      if (options?.onRequest) options.onRequest(args, onRequestResolve);
+      else onrequest(args, onRequestResolve);
 
-      if (options?.integrationFn) {
-        const integrate = options.integrationFn(...args);
-        request = integrate.request;
-        response = integrate.response;
-      } else [request, response] = args;
-      // Parse req.url
-      switch (request.path || parseUrl(request, true).pathname) {
-        case path:
-          return parseNodeRequest(request, onBodyParsed);
-        case playgroundPath:
-          return sendResponse({
-            status: 200,
-            body: renderPlayground({
-              endpoint: path,
-              subscriptionEndpoint: this.subscriptionPath,
-            }),
-            headers: { 'content-type': 'text/html; charset=utf-8' },
-          });
-        default:
-          return options?.onNoMatch
-            ? options.onNoMatch(...args)
-            : onnomatch(response);
+      function onRequestResolve(request: ExtendedRequest) {
+        switch (request.path || parseUrl(request, true).pathname) {
+          case path:
+            return parseNodeRequest(request, onBodyParsed);
+          case playgroundPath:
+            return sendResponse({
+              status: 200,
+              body: renderPlayground({
+                endpoint: path,
+                subscriptionEndpoint: that.subscriptionPath,
+              }),
+              headers: { 'content-type': 'text/html; charset=utf-8' },
+            });
+          default:
+            return options?.onNoMatch
+              ? options.onNoMatch(...args)
+              : onnomatch(args[1]);
+        }
       }
 
-      function sendResponse(result: QueryResponse) {
-        return options?.onResponse
-          ? options.onResponse(result, ...args)
-          : sendresponse(result, request, response);
-      }
-
-      function sendError(error: any) {
-        return sendResponse({
-          status: error.status || 500,
-          body: fastStringify({ errors: [error] }),
-          headers: { 'content-type': 'application/json' },
-        });
-      }
-
-      function onBodyParsed(parseErr: any, parsedBody?: QueryBody) {
+      function onBodyParsed(
+        parseErr: any,
+        request: ExtendedRequest,
+        parsedBody?: QueryBody
+      ) {
         if (parseErr) return sendError(parseErr);
+        const params = getGraphQLParams({
+          queryParams: request.query || parseUrl(request, true).query || {},
+          body: parsedBody,
+        });
+        params.httpRequest = { method: request.method as string };
+        return onParamParsed(params);
+      }
+
+      function onParamParsed(params: Partial<QueryRequest>) {
         try {
           const contextFn = that.options.context;
           const context: TContext | Promise<TContext> =
@@ -92,14 +86,14 @@ export class GraphyneServer extends GraphyneCore {
           // FIXME: Types error
           return 'then' in context
             ? context.then(
-                (ctx: TContext) =>
-                  onContextResolved(ctx, parsedBody as QueryBody),
+                (resolvedCtx: TContext) =>
+                  onContextResolved(resolvedCtx, params),
                 (error: any) => {
                   error.message = `Context creation failed: ${error.message}`;
                   return sendError(error);
                 }
               )
-            : onContextResolved(context, parsedBody as QueryBody);
+            : onContextResolved(context, params);
         } catch (error) {
           error.message = `Context creation failed: ${error.message}`;
           return sendError(error);
@@ -108,13 +102,8 @@ export class GraphyneServer extends GraphyneCore {
 
       function onContextResolved(
         context: Record<string, any>,
-        parsedBody: QueryBody
+        params: Partial<QueryRequest>
       ) {
-        const params = getGraphQLParams({
-          queryParams: request.query || parseUrl(request, true).query || {},
-          body: parsedBody,
-        });
-
         that.runQuery(
           {
             query: params.query,
@@ -122,11 +111,25 @@ export class GraphyneServer extends GraphyneCore {
             variables: params.variables,
             operationName: params.operationName,
             httpRequest: {
-              method: request.method as string,
+              method: params.httpRequest?.method as string,
             },
           },
           sendResponse
         );
+      }
+
+      function sendResponse(result: QueryResponse) {
+        return options?.onResponse
+          ? options.onResponse(result, ...args)
+          : sendresponse(result, args[1]);
+      }
+
+      function sendError(error: any) {
+        return sendResponse({
+          status: error.status || 500,
+          body: fastStringify({ errors: [error] }),
+          headers: { 'content-type': 'application/json' },
+        });
       }
     };
   }

--- a/packages/graphyne-server/src/types.ts
+++ b/packages/graphyne-server/src/types.ts
@@ -1,5 +1,11 @@
 import { IncomingMessage, ServerResponse } from 'http';
-import { QueryResponse } from 'graphyne-core';
+import {
+  QueryResponse,
+  QueryBody,
+  QueryRequest,
+  Config,
+  GraphyneCore,
+} from 'graphyne-core';
 
 export type IntegrationFunction = (
   ...args: any[]
@@ -30,3 +36,25 @@ export type ExtendedRequest = IncomingMessage & {
   path?: string;
   query?: Record<string, string>;
 };
+
+export interface HandlerInstance {
+  next: null;
+  args: any[];
+  options: HandlerConfig | undefined;
+  onRequestResolve: (request: ExtendedRequest) => void;
+  onBodyParsed: (
+    parseErr: any,
+    request: ExtendedRequest,
+    parsedBody?: QueryBody
+  ) => void;
+  onParamParsed: (params: Partial<QueryRequest>) => void;
+  onContextResolved: (
+    context: Record<string, any>,
+    params: Partial<QueryRequest>
+  ) => void;
+  sendResponse: (result: QueryResponse) => void;
+  sendError: (error: any) => void;
+  graphyneOpt: Config;
+  runQuery: GraphyneCore['runQuery'];
+  subscriptionPath: GraphyneCore['subscriptionPath'];
+}

--- a/packages/graphyne-server/src/types.ts
+++ b/packages/graphyne-server/src/types.ts
@@ -23,5 +23,10 @@ export interface HandlerConfig {
     { status, body, headers }: QueryResponse,
     ...args: any[]
   ) => void;
-  integrationFn?: IntegrationFunction;
+  onRequest?: (args: any[], done: (req: IncomingMessage) => void) => void;
 }
+
+export type ExtendedRequest = IncomingMessage & {
+  path?: string;
+  query?: Record<string, string>;
+};

--- a/packages/graphyne-server/src/types.ts
+++ b/packages/graphyne-server/src/types.ts
@@ -1,11 +1,5 @@
 import { IncomingMessage, ServerResponse } from 'http';
-import {
-  QueryResponse,
-  QueryBody,
-  QueryRequest,
-  Config,
-  GraphyneCore,
-} from 'graphyne-core';
+import { QueryResponse } from 'graphyne-core';
 
 export type IntegrationFunction = (
   ...args: any[]
@@ -36,25 +30,3 @@ export type ExtendedRequest = IncomingMessage & {
   path?: string;
   query?: Record<string, string>;
 };
-
-export interface HandlerInstance {
-  next: null;
-  args: any[];
-  options: HandlerConfig | undefined;
-  onRequestResolve: (request: ExtendedRequest) => void;
-  onBodyParsed: (
-    parseErr: any,
-    request: ExtendedRequest,
-    parsedBody?: QueryBody
-  ) => void;
-  onParamParsed: (params: Partial<QueryRequest>) => void;
-  onContextResolved: (
-    context: Record<string, any>,
-    params: Partial<QueryRequest>
-  ) => void;
-  sendResponse: (result: QueryResponse) => void;
-  sendError: (error: any) => void;
-  graphyneOpt: Config;
-  runQuery: GraphyneCore['runQuery'];
-  subscriptionPath: GraphyneCore['subscriptionPath'];
-}

--- a/packages/graphyne-server/tests/graphyneServer.spec.ts
+++ b/packages/graphyne-server/tests/graphyneServer.spec.ts
@@ -44,12 +44,14 @@ const schemaHello = makeExecutableSchema({
 });
 
 describe('createHandler', () => {
-  it('maps req and res using integrationFn', async () => {
+  it('maps request using onRequest', async () => {
     const graphyne = new GraphyneServer({
       schema: schemaHello,
     });
     const handler = graphyne.createHandler({
-      integrationFn: ({ req, res }) => ({ request: req, response: res }),
+      onRequest: ([ctx], done) => done(ctx.req),
+      onResponse: ({ status, body, headers }, ctx) =>
+        ctx.res.writeHead(status, headers).end(body),
     });
     const server = createServer((req, res) => {
       const ctx = { req, res };
@@ -108,10 +110,6 @@ describe('createHandler', () => {
     });
     const server = createServer(
       graphyne.createHandler({
-        integrationFn: (req, res) => ({
-          request: req,
-          response: res,
-        }),
         onResponse: (result, req, res) => {
           res.setHeader('test', 'ok');
           res.end(result.body);

--- a/packages/graphyne-server/tests/graphyneServer.spec.ts
+++ b/packages/graphyne-server/tests/graphyneServer.spec.ts
@@ -126,9 +126,20 @@ describe('createHandler', () => {
     const graphyne = new GraphyneServer({
       schema: schemaHello,
     });
-    it('by default renders 404', async () => {
-      const server = createServer(graphyne.createHandler());
-      await request(server).get('/api').expect('not found');
+    it('by default calling `onResponse', async () => {
+      const server = createServer(
+        graphyne.createHandler({
+          onResponse: (result, req, res) => {
+            res.setHeader('test', 'ok');
+            res.writeHead(result.status, result.headers).end(result.body);
+          },
+        })
+      );
+      await request(server)
+        .get('/api')
+        .expect('not found')
+        .expect(404)
+        .expect('test', 'ok');
     });
     it('renders custom behavior in onNoMatch', async () => {
       const server = createServer(

--- a/packages/graphyne-server/tests/graphyneServer.spec.ts
+++ b/packages/graphyne-server/tests/graphyneServer.spec.ts
@@ -166,6 +166,17 @@ describe('HTTP handler', () => {
       .get('/graphql')
       .query({ query: 'query { helloMe }' })
       .expect('{"errors":[{"message":"Context creation failed: uh oh"}]}');
+    // Non promise function
+    const server2 = createGQLServer({
+      schema: schemaHello,
+      context: () => {
+        throw new Error('uh oh');
+      },
+    });
+    await request(server2)
+      .get('/graphql')
+      .query({ query: 'query { helloMe }' })
+      .expect('{"errors":[{"message":"Context creation failed: uh oh"}]}');
   });
   describe('resolves options.context that is', () => {
     it('an object', async () => {

--- a/packages/graphyne-server/tests/integration.spec.ts
+++ b/packages/graphyne-server/tests/integration.spec.ts
@@ -142,11 +142,8 @@ describe('Integrations', () => {
     const app = new Koa();
     const handler = graphyne.createHandler({
       playground: true,
-      integrationFn: (ctx) => {
-        return {
-          request: ctx.req,
-          response: ctx.res,
-        };
+      onRequest: ([ctx], done) => {
+        done(ctx.req);
       },
       onResponse: ({ headers, body, status }, ctx) => {
         ctx.status = status;

--- a/packages/graphyne-server/tests/integration.spec.ts
+++ b/packages/graphyne-server/tests/integration.spec.ts
@@ -140,22 +140,23 @@ describe('Integrations', () => {
   describe('koa', () => {
     const Koa = require('koa');
     const app = new Koa();
-    const handler = graphyne.createHandler({
-      playground: true,
-      onRequest: ([ctx], done) => {
-        done(ctx.req);
-      },
-      onResponse: ({ headers, body, status }, ctx) => {
-        ctx.status = status;
-        ctx.set(headers);
-        ctx.body = body;
-      },
-      onNoMatch: (ctx) => {
-        ctx.status = 404;
-        ctx.body = 'not found';
-      },
-    });
-    app.use(async (ctx, next) => handler(ctx));
+    app.use(
+      graphyne.createHandler({
+        playground: true,
+        onRequest: ([ctx], done) => {
+          done(ctx.req);
+        },
+        onResponse: ({ headers, body, status }, ctx) => {
+          ctx.status = status;
+          ctx.set(headers);
+          ctx.body = body;
+        },
+        onNoMatch: (ctx) => {
+          ctx.status = 404;
+          ctx.body = 'not found';
+        },
+      })
+    );
     let server;
     beforeEach(() => {
       server = app.listen();

--- a/packages/graphyne-server/tests/utils.spec.ts
+++ b/packages/graphyne-server/tests/utils.spec.ts
@@ -7,7 +7,7 @@ describe('core utils', () => {
   describe('parseNodeRequest', () => {
     it('parse application/json properly', async () => {
       const server = createServer((req, res) => {
-        parseNodeRequest(req, (err, parsedBody) => {
+        parseNodeRequest(req, (err, req, parsedBody) => {
           res.end(JSON.stringify(parsedBody));
         });
       });
@@ -19,7 +19,7 @@ describe('core utils', () => {
     });
     it('parse application/graphql properly', async () => {
       const server = createServer((req, res) => {
-        parseNodeRequest(req, (err, parsedBody) => {
+        parseNodeRequest(req, (err, req, parsedBody) => {
           res.end(JSON.stringify(parsedBody));
         });
       });
@@ -32,13 +32,13 @@ describe('core utils', () => {
     it('returns if req.body has been parsed', (done) => {
       const req = { body: { query: 1 } };
       // @ts-ignore
-      parseNodeRequest(req, (err, parsedBody) => {
+      parseNodeRequest(req, (err, req, parsedBody) => {
         done(assert.deepStrictEqual(parsedBody, req.body));
       });
     });
     it('errors body is malformed', async () => {
       const server = createServer((req, res) => {
-        parseNodeRequest(req, (err, parsedBody) => {
+        parseNodeRequest(req, (err, req, parsedBody) => {
           if (err) res.statusCode = err.status;
           res.end(JSON.stringify(parsedBody));
         });
@@ -52,7 +52,7 @@ describe('core utils', () => {
     describe('do not parse body', () => {
       it('with empty content type', async () => {
         const server = createServer((req, res) => {
-          parseNodeRequest(req, (err, parsedBody) => {
+          parseNodeRequest(req, (err, req, parsedBody) => {
             res.end(JSON.stringify(parsedBody));
           });
         });
@@ -64,7 +64,7 @@ describe('core utils', () => {
       });
       it('with invalid content-type', async () => {
         const server = createServer((req, res) => {
-          parseNodeRequest(req, (err, parsedBody) => {
+          parseNodeRequest(req, (err, req, parsedBody) => {
             res.end(JSON.stringify(parsedBody));
           });
         });


### PR DESCRIPTION
This replaces `integrationFn` with `onRequest`. Instead of asking for both `request` and `response`, we only need the user to resolve with `request`. (this can speed up by not having to call the function with a constructed object).

Also the idea of `integrationFn` makes things like `onNoMatch` and `onResponse` not clear.

Even though this change will force the users to do extra works (like defining `onNoMatch` and `onResponse` while they used to not have to after defining `integrationFn`), it makes things clearer.