### PR TITLE
Add custom formatError function

### DIFF
--- a/packages/graphyne-core/README.md
+++ b/packages/graphyne-core/README.md
@@ -23,7 +23,7 @@ Constructing a Graphyne GraphQL server. It accepts the following options:
 | cache | `GraphyneServer` creates **two** in-memory LRU cache: One for compiled queries and another for invalid queries. This value defines max items to hold in **each** cache. Pass `false` to disable cache. | `1024` |
 | formatError | An optional function which will be used to format any errors from GraphQL execution result. | [`formatError`](https://github.com/graphql/graphql-js/blob/master/src/error/formatError.js) |
 
-### `GraphyneServer#runQuery({ query, variables, operationName, context, httpMethod }, callback)`
+### `GraphyneCore#runQuery({ query, variables, operationName, context, httpMethod }, callback)`
 
 Execute the GraphQL query:
 
@@ -39,7 +39,7 @@ When the execution is done, the callback function will be called with an object 
 - `headers`: The headers that should be set for the HTTP Response.
 - `body`: The stringified body of the HTTP Response.
 
-### `GraphyneServer#getCompiledQuery(query, operationName)`
+### `GraphyneCore#getCompiledQuery(query, operationName)`
 
 Find the `graphql-jit` [compiled query](https://github.com/zalando-incubator/graphql-jit#compiledquery--compilequeryschema-document-operationname-compileroptions) in the cache or create one if not existed.
 

--- a/packages/graphyne-core/README.md
+++ b/packages/graphyne-core/README.md
@@ -11,7 +11,7 @@ Graphyne is a **lightning-fast** JavaScript GraphQL Server. Check out its [docum
 
 ## API
 
-### `new GraphyneServer(options)`
+### `new GraphyneCore(options)`
 
 Constructing a Graphyne GraphQL server. It accepts the following options:
 
@@ -21,6 +21,7 @@ Constructing a Graphyne GraphQL server. It accepts the following options:
 | context | An object or function called to creates a context shared across resolvers per request. The function accepts the framework's [signature function](#framework-specific-integration). | `{}` |
 | rootValue | A value or function called with the parsed `Document` that creates the root value passed to the GraphQL executor. | `{}` |
 | cache | `GraphyneServer` creates **two** in-memory LRU cache: One for compiled queries and another for invalid queries. This value defines max items to hold in **each** cache. Pass `false` to disable cache. | `1024` |
+| formatError | An optional function which will be used to format any errors from GraphQL execution result. | [`formatError`](https://github.com/graphql/graphql-js/blob/master/src/error/formatError.js) |
 
 ### `GraphyneServer#runQuery({ query, variables, operationName, context, httpMethod }, callback)`
 

--- a/packages/graphyne-core/src/core.ts
+++ b/packages/graphyne-core/src/core.ts
@@ -185,7 +185,6 @@ export class GraphyneCore {
         : fastStringify)(o);
       flatstr(payload);
       cb({
-        rawBody: obj,
         body: payload,
         status: code,
         headers: { 'content-type': 'application/json' },

--- a/packages/graphyne-core/src/core.ts
+++ b/packages/graphyne-core/src/core.ts
@@ -172,13 +172,14 @@ export class GraphyneCore {
   ): void | Promise<void> {
     let compiledQuery: CompiledQuery | ExecutionResult;
 
-    function createResponse(code: number, obj: ExecutionResult) {
+    const createResponse = (code: number, obj: ExecutionResult) => {
       const o: {
         data?: ExecutionResult['data'];
         errors?: GraphQLFormattedError[];
       } = {};
       if (obj.data) o.data = obj.data;
-      if (obj.errors) o.errors = obj.errors.map(formatError);
+      if (obj.errors)
+        o.errors = obj.errors.map(this.options.formatError || formatError);
       const payload = (compiledQuery && isCompiledQuery(compiledQuery)
         ? compiledQuery.stringify
         : fastStringify)(o);
@@ -189,7 +190,7 @@ export class GraphyneCore {
         status: code,
         headers: { 'content-type': 'application/json' },
       });
-    }
+    };
 
     try {
       if (!query)

--- a/packages/graphyne-core/src/types.ts
+++ b/packages/graphyne-core/src/types.ts
@@ -35,7 +35,6 @@ export interface QueryRequest extends QueryBody {
 export interface QueryResponse {
   status: number;
   body: string;
-  rawBody: ExecutionResult;
   headers: Record<string, string>;
 }
 

--- a/packages/graphyne-core/src/types.ts
+++ b/packages/graphyne-core/src/types.ts
@@ -3,6 +3,7 @@ import {
   GraphQLSchema,
   DocumentNode,
   ExecutionResult,
+  GraphQLFormattedError,
 } from 'graphql';
 import { CompiledQuery } from 'graphql-jit';
 
@@ -13,6 +14,7 @@ export interface Config {
   context?: TContext | ((...args: any[]) => TContext | Promise<TContext>);
   rootValue?: ((parsedQuery: DocumentNode) => any) | any;
   cache?: number | boolean;
+  formatError?: (error: GraphQLError) => GraphQLFormattedError;
 }
 
 export type HTTPHeaders = Record<string, string | string[] | undefined>;

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -51,7 +51,6 @@ function testCase(
       ...options,
       // @ts-ignore
     }).runQuery(queryRequest, (result) => {
-      delete result.rawBody;
       if (typeof expected.body === 'function') {
         return expected.body(result.body) ? resolve() : reject('no match');
       }

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -327,4 +327,23 @@ describe('HTTP Operations', () => {
       }
     );
   });
+  it('allows custom formatError', () => {
+    return testCase(
+      { query: 'query { throwMe }' },
+      {
+        body: (str) => {
+          const {
+            errors: [err],
+          } = JSON.parse(str);
+          assert.deepStrictEqual(err.message, 'Internal server error');
+          return true;
+        },
+      },
+      {
+        formatError: (err) => {
+          return new Error('Internal server error');
+        },
+      }
+    );
+  });
 });

--- a/packages/graphyne-server/README.md
+++ b/packages/graphyne-server/README.md
@@ -109,7 +109,6 @@ This will be a function called to send back the HTTP response, where `args` are 
 - `status` (the status code that should be set)
 - `headers` (the headers that should be set)
 - `body` (the stringified response body).
-- `rawBody` (the raw execution result object which contains `data` and the **unformatted** `errors`)
 
 By default, `onResponse` assumes `response` is the second argument of the signature function and call `response.writeHead` and `response.end` accordingly.
 
@@ -124,8 +123,6 @@ graphyne.createHandler({
   }
 })
 ```
-
-In addition to acting as a compatible layer, `onResponse` can be used to format GraphQL `errors` and customize behaviors (sending a different status code, etc.). It helps by exposing `result.rawBody`, which is GraphQL execution result.
 
 `onNoMatch(result, ...args)`
 

--- a/packages/graphyne-server/README.md
+++ b/packages/graphyne-server/README.md
@@ -48,6 +48,7 @@ Constructing a Graphyne GraphQL server. It accepts the following options:
 | context | An object or function called to creates a context shared across resolvers per request. The function accepts the framework's [signature function](#framework-specific-integration). | `{}` |
 | rootValue | A value or function called with the parsed `Document` that creates the root value passed to the GraphQL executor. | `{}` |
 | cache | `GraphyneServer` creates **two** in-memory LRU cache: One for compiled queries and another for invalid queries. This value defines max items to hold in **each** cache. Pass `false` to disable cache. | `1024` |
+| formatError | An optional function which will be used to format any errors from GraphQL execution result. | [`formatError`](https://github.com/graphql/graphql-js/blob/master/src/error/formatError.js) |
 
 ### `GraphyneServer#createHandler(options)`
 

--- a/packages/graphyne-server/src/graphyneServer.ts
+++ b/packages/graphyne-server/src/graphyneServer.ts
@@ -101,9 +101,7 @@ export class GraphyneServer extends GraphyneCore {
         );
       }
 
-      function sendResponse(
-        result: Omit<QueryResponse, 'rawBody'> & { rawBody?: ExecutionResult }
-      ) {
+      function sendResponse(result: QueryResponse) {
         if (options?.onResponse) return options.onResponse(result, ...args);
         else
           return (args[1] as ServerResponse)

--- a/packages/graphyne-server/src/types.ts
+++ b/packages/graphyne-server/src/types.ts
@@ -21,12 +21,7 @@ export interface HandlerConfig {
       };
   onNoMatch?: (...args: any[]) => void;
   onResponse?: (
-    {
-      status,
-      body,
-      headers,
-      rawBody,
-    }: Omit<QueryResponse, 'rawBody'> & { rawBody?: ExecutionResult },
+    { status, body, headers }: QueryResponse,
     ...args: any[]
   ) => void;
   onRequest?: (args: any[], done: (req: IncomingMessage) => void) => void;

--- a/packages/graphyne-server/tests/utils.spec.ts
+++ b/packages/graphyne-server/tests/utils.spec.ts
@@ -80,7 +80,7 @@ describe('core utils', () => {
     it('works with queryParams', () => {
       const { query, variables } = getGraphQLParams({
         queryParams: { query: 'ok', variables: `{ "ok": "no" }` },
-        body: {},
+        body: null,
       });
       assert.deepStrictEqual(query, 'ok');
       assert.deepStrictEqual(variables?.ok, 'no');

--- a/packages/graphyne-server/tests/utils.spec.ts
+++ b/packages/graphyne-server/tests/utils.spec.ts
@@ -7,7 +7,7 @@ describe('core utils', () => {
   describe('parseNodeRequest', () => {
     it('parse application/json properly', async () => {
       const server = createServer((req, res) => {
-        parseNodeRequest(req, (err, req, parsedBody) => {
+        parseNodeRequest(req, (err, parsedBody) => {
           res.end(JSON.stringify(parsedBody));
         });
       });
@@ -19,7 +19,7 @@ describe('core utils', () => {
     });
     it('parse application/graphql properly', async () => {
       const server = createServer((req, res) => {
-        parseNodeRequest(req, (err, req, parsedBody) => {
+        parseNodeRequest(req, (err, parsedBody) => {
           res.end(JSON.stringify(parsedBody));
         });
       });
@@ -32,13 +32,13 @@ describe('core utils', () => {
     it('returns if req.body has been parsed', (done) => {
       const req = { body: { query: 1 } };
       // @ts-ignore
-      parseNodeRequest(req, (err, req, parsedBody) => {
+      parseNodeRequest(req, (err, parsedBody) => {
         done(assert.deepStrictEqual(parsedBody, req.body));
       });
     });
     it('errors body is malformed', async () => {
       const server = createServer((req, res) => {
-        parseNodeRequest(req, (err, req, parsedBody) => {
+        parseNodeRequest(req, (err, parsedBody) => {
           if (err) res.statusCode = err.status;
           res.end(JSON.stringify(parsedBody));
         });
@@ -52,7 +52,7 @@ describe('core utils', () => {
     describe('do not parse body', () => {
       it('with empty content type', async () => {
         const server = createServer((req, res) => {
-          parseNodeRequest(req, (err, req, parsedBody) => {
+          parseNodeRequest(req, (err, parsedBody) => {
             res.end(JSON.stringify(parsedBody));
           });
         });
@@ -64,7 +64,7 @@ describe('core utils', () => {
       });
       it('with invalid content-type', async () => {
         const server = createServer((req, res) => {
-          parseNodeRequest(req, (err, req, parsedBody) => {
+          parseNodeRequest(req, (err, parsedBody) => {
             res.end(JSON.stringify(parsedBody));
           });
         });
@@ -100,13 +100,6 @@ describe('core utils', () => {
       });
       assert.deepStrictEqual(query, 'ok');
       assert.deepStrictEqual(variables?.ok, 'no');
-    });
-    it('see body as query if is string', () => {
-      const { query } = getGraphQLParams({
-        queryParams: {},
-        body: `query { hello }`,
-      });
-      assert.deepStrictEqual(query, 'query { hello }');
     });
   });
 });


### PR DESCRIPTION
This allows the usage of formatError in `new GraphyneServer` to format errors instead of using the default one.

Since `rawBody` used to help aid formating error, it will be removed since the functionality is also covered in `formatError`.