### PR TITLE
Remove error cache and refactor

### DIFF
--- a/packages/graphyne-core/src/types.ts
+++ b/packages/graphyne-core/src/types.ts
@@ -27,7 +27,7 @@ export interface QueryBody {
 
 export interface QueryRequest extends QueryBody {
   context: Record<string, any>;
-  httpMethod?: string;
+  httpMethod: string;
 }
 
 export interface QueryResponse {
@@ -40,5 +40,4 @@ export interface QueryCache {
   operation: string;
   document: DocumentNode;
   compiledQuery: CompiledQuery;
-  errors: readonly GraphQLError[];
 }

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -39,12 +39,15 @@ const schema = makeExecutableSchema({
 });
 
 function testCase(
-  queryRequest: QueryBody &
-    Pick<QueryRequest, 'httpMethod'> & { context?: Record<string, any> },
+  queryRequest: QueryBody & {
+    context?: Record<string, any>;
+    httpMethod?: string;
+  },
   expected: Partial<QueryResponse> | { body: (b: string) => boolean },
   options?: Partial<Config>
 ) {
   if (!queryRequest.context) queryRequest.context = {};
+  if (!queryRequest.httpMethod) queryRequest.httpMethod = 'POST';
   return new Promise((resolve, reject) => {
     new GraphyneCore({
       schema,

--- a/packages/graphyne-ws/src/graphyneWebsocket.ts
+++ b/packages/graphyne-ws/src/graphyneWebsocket.ts
@@ -120,7 +120,13 @@ export class GraphyneWebSocketConnection {
       const { query, variables, operationName } = payload || {};
       if (!query) throw new GraphQLError('Must provide query string.');
 
-      const { document, operation } = this.graphyne.getCompiledQuery(query);
+      const {
+        document,
+        operation,
+        compiledQuery,
+      } = this.graphyne.getCompiledQuery(query);
+
+      if (!document) throw compiledQuery as ExecutionResult;
 
       if (operation !== 'subscription')
         throw new GraphQLError('Not a subscription operation');

--- a/packages/graphyne-ws/tests/graphyneWebsocket.spec.ts
+++ b/packages/graphyne-ws/tests/graphyneWebsocket.spec.ts
@@ -192,7 +192,7 @@ describe('graphyne-ws', () => {
         resolve(
           assert.deepStrictEqual(
             chunk,
-            `{"type":"data","id":1,"payload":{"errors":[{"message":"Must provide query string."}]}}`
+            `{"type":"error","id":1,"payload":{"errors":[{"message":"Must provide query string."}]}}`
           )
         );
       });
@@ -228,7 +228,7 @@ describe('graphyne-ws', () => {
         resolve(
           assert.deepStrictEqual(
             chunk,
-            `{"type":"data","id":1,"payload":{"errors":[{"message":"Not a subscription operation"}]}}`
+            `{"type":"error","id":1,"payload":{"errors":[{"message":"Not a subscription operation"}]}}`
           )
         );
       });


### PR DESCRIPTION
This library is originally inspired by `fastify-gql` cache strategy, which creates an additional error cache for DDOS protection. However, I find that this should be handled elsewhere (such as using CloudFlare), not in this module.