### PR TITLE
Remove fastStringify function and apply formatError everywhere

### DIFF
--- a/packages/graphyne-core/package.json
+++ b/packages/graphyne-core/package.json
@@ -21,7 +21,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "fast-json-stringify": "^2.0.0",
     "flatstr": "^1.0.12",
     "graphql-jit": "^0.4.3",
     "tiny-lru": "^7.0.2"

--- a/packages/graphyne-core/src/core.ts
+++ b/packages/graphyne-core/src/core.ts
@@ -22,7 +22,7 @@ export class GraphyneCore {
   protected options: Config;
   public subscriptionPath: string = '/';
 
-  protected formatErrorFn: (error: GraphQLError) => GraphQLFormattedError;
+  formatErrorFn: (error: GraphQLError) => GraphQLFormattedError;
 
   constructor(options: Config) {
     // validate options

--- a/packages/graphyne-core/src/index.ts
+++ b/packages/graphyne-core/src/index.ts
@@ -1,3 +1,3 @@
-export { GraphyneCore, fastStringify } from './core';
+export { GraphyneCore } from './core';
 export * from './types';
 export { renderPlayground } from './playground';

--- a/packages/graphyne-server/src/graphyneServer.ts
+++ b/packages/graphyne-server/src/graphyneServer.ts
@@ -4,7 +4,6 @@ import {
   Config,
   QueryResponse,
   renderPlayground,
-  fastStringify,
   TContext,
   QueryRequest,
 } from 'graphyne-core';
@@ -103,7 +102,7 @@ export class GraphyneServer extends GraphyneCore {
       sendResponse(
         {
           status: error.status || 500,
-          body: fastStringify({ errors: [error] }),
+          body: JSON.stringify({ errors: [that.formatErrorFn(error)] }),
           headers: { 'content-type': 'application/json' },
         },
         args

--- a/packages/graphyne-worker/README.md
+++ b/packages/graphyne-worker/README.md
@@ -68,6 +68,7 @@ Constructing a Graphyne GraphQL worker. It accepts the following options:
 | schema | A `GraphQLSchema` instance. It can be created using `makeExecutableSchema` from [graphql-tools](https://github.com/apollographql/graphql-tools). | (required) |
 | context | An object or function called to creates a context shared across resolvers per request. The function accepts the framework's [signature function](#framework-specific-integration). | `{}` |
 | rootValue | A value or function called with the parsed `Document` that creates the root value passed to the GraphQL executor. | `{}` |
+| formatError | An optional function which will be used to format any errors from GraphQL execution result. | [`formatError`](https://github.com/graphql/graphql-js/blob/master/src/error/formatError.js) |
 
 ### `GraphyneWorker#createHandler(options)`
 

--- a/packages/graphyne-worker/src/graphyneWorker.ts
+++ b/packages/graphyne-worker/src/graphyneWorker.ts
@@ -1,7 +1,6 @@
 import {
   GraphyneCore,
   Config,
-  fastStringify,
   QueryBody,
   renderPlayground,
 } from 'graphyne-core';
@@ -31,10 +30,13 @@ export class GraphyneWorker extends GraphyneCore {
         typeof contextFn === 'function' ? await contextFn(request) : contextFn;
     } catch (err) {
       err.message = `Context creation failed: ${err.message}`;
-      return new Response(fastStringify({ errors: [err] }), {
-        status: err.status || 500,
-        headers: { 'content-type': 'application/json' },
-      });
+      return new Response(
+        JSON.stringify({ errors: [this.formatErrorFn(err)] }),
+        {
+          status: err.status || 500,
+          headers: { 'content-type': 'application/json' },
+        }
+      );
     }
     let body: QueryBody | undefined;
 
@@ -51,10 +53,13 @@ export class GraphyneWorker extends GraphyneCore {
               body = await request.json();
             } catch (err) {
               err.status = 400;
-              return new Response(fastStringify({ errors: [err] }), {
-                status: 400,
-                headers: { 'content-type': 'application/json' },
-              });
+              return new Response(
+                JSON.stringify({ errors: [this.formatErrorFn(err)] }),
+                {
+                  status: 400,
+                  headers: { 'content-type': 'application/json' },
+                }
+              );
             }
             break;
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,15 +3756,6 @@ fast-json-stringify@^1.13.0, fast-json-stringify@^1.18.0:
     deepmerge "^4.2.2"
     string-similarity "^4.0.1"
 
-fast-json-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-2.0.0.tgz#37d3809000cdc05d4aa0fd2831847039c0d1940e"
-  integrity sha512-q3b2sMbYySzXdQSX4F9ILle3oJzpV1/7p5wPfpDL3mH2euzdL7qiEeg9B4lS/lGTjYBriAplSnpoqYLTy/p8Ew==
-  dependencies:
-    ajv "^6.11.0"
-    deepmerge "^4.2.2"
-    string-similarity "^4.0.1"
-
 fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"


### PR DESCRIPTION
Because using `fastJson` just to serialize failed GraphQL execution is overkill. Also `formatError` is not used everywhere.