### PR TITLE
Add onGraphyneWebSocketConnection and make GraphyneWebSocketConnection an event emitter 

### DIFF
--- a/packages/graphyne-ws/README.md
+++ b/packages/graphyne-ws/README.md
@@ -100,30 +100,30 @@ wss.on('close', function close() {
 
 An instance of `GraphyneWebSocketConnection` extends `EventEmitter`.
 
-It emits several events **after finished proccessing (connection acknowledge/subscription started or stopped/connection terminated)** an incoming message. Below are expected events:
+It emits several events upon connection acknowledged, subscription started or stopped, and connection terminated.
 
 ```javascript
 import { startSubscriptionServer } from "graphyne-ws";
 
 startSubscriptionServer({
   onGraphyneWebSocketConnection: (connection) => {
-    // called after the connection is init and the websocket server sends GQL_CONNECTION_ACK
+    // called after the connection is initialized and acknowledged
     connection.on('connection_init', (connectionParams) => {
       // optional parameters that the client specifies in connectionParams
     });
 
-    // called after a subscription operation is started
+    // called after a subscription operation has been started
     connection.on('subscription_start', (id, payload) => {
       // id is the GraphQL operation ID
       // payload is the GQL payload with `query`, `variables`, and `operationName`.
     });
 
-    // called after the operation is stopped
+    // called after the operation has been stopped
     connection.on('subscription_stop', (id) => {
       // id is the GraphQL operation ID that was stopped
     });
 
-    // called after fulfilling client request for the connection to be terminated
+    // called after the connection is terminated
     connection.on('connection_terminate', () => {
       // This event has no argument
     });

--- a/packages/graphyne-ws/README.md
+++ b/packages/graphyne-ws/README.md
@@ -61,6 +61,73 @@ Create an instance of `GraphyneWebSocketServer` **and** listen to incoming conne
   - `connectionParams`: Object that is sent from the client. See an example in [`apollo-link-ws`](https://www.apollographql.com/docs/react/data/subscriptions/#authentication-over-websocket)
   - `socket`: The [WebSocket connection](https://github.com/websockets/ws/blob/HEAD/doc/ws.md#event-connection).
   - `request`: The incoming request.
+- `onGraphyneWebSocketConnection`: A function to call whenever a `GraphyneWebSocketConnection` is created. The only argument is the `GraphyneWebSocketConnection` instance.
+
+### `GraphyneWebSocketConnection`
+
+An instance of `GraphyneWebSocketConnection` extends `EventEmitter`.
+
+**WARNING: The following events are still experimental and may be changed at any time in the future!**
+
+It emits on every message with the event being one of the [Client -> Server message types](src/messageTypes.ts) **after finished proccessing (connection acknowledge/subscription started or stopped/connection terminated)**. Below are expected events:
+
+```javascript
+import {
+  startSubscriptionServer,
+  GQL_CONNECTION_INIT,
+  GQL_START,
+  GQL_STOP,
+  GQL_CONNECTION_TERMINATE,
+} from "graphyne-ws";
+
+startSubscriptionServer({
+  onGraphyneWebSocketConnection: (connection) => {
+    // The following are emitted by GraphyneWebSocketConnection
+    connection.on(GQL_CONNECTION_INIT, (connectionParams) => {
+      // optional parameters that the client specifies in connectionParams
+    });
+    connection.on(GQL_START, (id, payload) => {
+      // id is the GraphQL operation ID
+      // payload is the GQL payload with `query`, `variables`, and `operationName`.
+    });
+    connection.on(GQL_STOP, (id) => {
+      // id is the GraphQL operation ID that was stopped
+    });
+    connection.on(GQL_CONNECTION_TERMINATE, () => {
+      // This event has no argument, signifying that the client requests the connection to be terminated
+    });
+  },
+});
+```
+
+`GraphyneWebSocketConnection` also exposes `socket` which is a `WebSocket`. This may be helpful if you want to implement a ping-pong according to [RFC 6455](https://tools.ietf.org/html/rfc6455) to detect broken connections using "heartbeat":
+
+```javascript
+const PING_PONG_INTERVAL = 10000; // 10 sec
+
+const wss = startSubscriptionServer({
+  onGraphyneWebSocketConnection: (connection) => {
+    connection.socket.on('pong', () => {
+      socket.isAlive = true;
+    });
+  }
+})
+
+const wssPingPong = setInterval(() => {
+  wss.clients.forEach((ws) => {
+    if (ws.isAlive === false) {
+      ws.terminate();
+      return;
+    }]
+    ws.isAlive = false;
+    ws.ping();
+  });
+}, PING_PONG_INTERVAL);
+
+wss.on('close', function close() {
+  clearInterval(wssPingPong);
+});
+```
 
 ## Framework integration
 

--- a/packages/graphyne-ws/README.md
+++ b/packages/graphyne-ws/README.md
@@ -61,46 +61,13 @@ Create an instance of `GraphyneWebSocketServer` **and** listen to incoming conne
   - `connectionParams`: Object that is sent from the client. See an example in [`apollo-link-ws`](https://www.apollographql.com/docs/react/data/subscriptions/#authentication-over-websocket)
   - `socket`: The [WebSocket connection](https://github.com/websockets/ws/blob/HEAD/doc/ws.md#event-connection).
   - `request`: The incoming request.
-- `onGraphyneWebSocketConnection`: A function to call whenever a `GraphyneWebSocketConnection` is created. The only argument is the `GraphyneWebSocketConnection` instance.
+- `onGraphyneWebSocketConnection`: A function to called with the `GraphyneWebSocketConnection` instance whenever one is created (on every websocket connection).
 
 ### `GraphyneWebSocketConnection`
 
-An instance of `GraphyneWebSocketConnection` extends `EventEmitter`.
+#### GraphyneWebSocketConnection#socket
 
-**WARNING: The following events are still experimental and may be changed at any time in the future!**
-
-It emits on every message with the event being one of the [Client -> Server message types](src/messageTypes.ts) **after finished proccessing (connection acknowledge/subscription started or stopped/connection terminated)**. Below are expected events:
-
-```javascript
-import {
-  startSubscriptionServer,
-  GQL_CONNECTION_INIT,
-  GQL_START,
-  GQL_STOP,
-  GQL_CONNECTION_TERMINATE,
-} from "graphyne-ws";
-
-startSubscriptionServer({
-  onGraphyneWebSocketConnection: (connection) => {
-    // The following are emitted by GraphyneWebSocketConnection
-    connection.on(GQL_CONNECTION_INIT, (connectionParams) => {
-      // optional parameters that the client specifies in connectionParams
-    });
-    connection.on(GQL_START, (id, payload) => {
-      // id is the GraphQL operation ID
-      // payload is the GQL payload with `query`, `variables`, and `operationName`.
-    });
-    connection.on(GQL_STOP, (id) => {
-      // id is the GraphQL operation ID that was stopped
-    });
-    connection.on(GQL_CONNECTION_TERMINATE, () => {
-      // This event has no argument, signifying that the client requests the connection to be terminated
-    });
-  },
-});
-```
-
-`GraphyneWebSocketConnection` also exposes `socket` which is a `WebSocket`. This may be helpful if you want to implement a ping-pong according to [RFC 6455](https://tools.ietf.org/html/rfc6455) to detect broken connections using "heartbeat":
+`GraphyneWebSocketConnection` exposes `socket` which is a `WebSocket`. This may be helpful if you want to implement a ping-pong according to [RFC 6455](https://tools.ietf.org/html/rfc6455) to detect broken connections using "heartbeat":
 
 ```javascript
 const PING_PONG_INTERVAL = 10000; // 10 sec
@@ -126,6 +93,47 @@ const wssPingPong = setInterval(() => {
 
 wss.on('close', function close() {
   clearInterval(wssPingPong);
+});
+```
+
+#### Events
+
+An instance of `GraphyneWebSocketConnection` extends `EventEmitter`.
+
+It emits **after finished proccessing (connection acknowledge/subscription started or stopped/connection terminated)** an incoming message. Below are expected events:
+
+```javascript
+import {
+  startSubscriptionServer,
+  GQL_CONNECTION_INIT,
+  GQL_START,
+  GQL_STOP,
+  GQL_CONNECTION_TERMINATE,
+} from "graphyne-ws";
+
+startSubscriptionServer({
+  onGraphyneWebSocketConnection: (connection) => {
+    // called after the connection is init and the websocket server sends GQL_CONNECTION_ACK
+    connection.on(GQL_CONNECTION_INIT, (connectionParams) => {
+      // optional parameters that the client specifies in connectionParams
+    });
+
+    // called after a subscription operation is started
+    connection.on(GQL_START, (id, payload) => {
+      // id is the GraphQL operation ID
+      // payload is the GQL payload with `query`, `variables`, and `operationName`.
+    });
+
+    // called after the operation is stopped
+    connection.on(GQL_STOP, (id) => {
+      // id is the GraphQL operation ID that was stopped
+    });
+
+    // called after fulfilling client request for the connection to be terminated
+    connection.on(GQL_CONNECTION_TERMINATE, () => {
+      // This event has no argument
+    });
+  },
 });
 ```
 

--- a/packages/graphyne-ws/README.md
+++ b/packages/graphyne-ws/README.md
@@ -67,10 +67,10 @@ Create an instance of `GraphyneWebSocketServer` **and** listen to incoming conne
 
 #### GraphyneWebSocketConnection#socket
 
-`GraphyneWebSocketConnection` exposes `socket` which is a `WebSocket`. This may be helpful if you want to implement a ping-pong according to [RFC 6455](https://tools.ietf.org/html/rfc6455) to detect broken connections using "heartbeat":
+`GraphyneWebSocketConnection` exposes `socket` which is a `WebSocket`. This is helpful if you want to implement something like a "heartbeat" to detect broken connections according to [RFC 6455 Ping-Pong](https://tools.ietf.org/html/rfc6455#section-5.5):
 
 ```javascript
-const PING_PONG_INTERVAL = 10000; // 10 sec
+const HEARTBEAT_INTERVAL = 10000; // 10 sec
 
 const wss = startSubscriptionServer({
   onGraphyneWebSocketConnection: (connection) => {
@@ -89,7 +89,7 @@ const wssPingPong = setInterval(() => {
     ws.isAlive = false;
     ws.ping();
   });
-}, PING_PONG_INTERVAL);
+}, HEARTBEAT_INTERVAL);
 
 wss.on('close', function close() {
   clearInterval(wssPingPong);
@@ -100,37 +100,31 @@ wss.on('close', function close() {
 
 An instance of `GraphyneWebSocketConnection` extends `EventEmitter`.
 
-It emits **after finished proccessing (connection acknowledge/subscription started or stopped/connection terminated)** an incoming message. Below are expected events:
+It emits several events **after finished proccessing (connection acknowledge/subscription started or stopped/connection terminated)** an incoming message. Below are expected events:
 
 ```javascript
-import {
-  startSubscriptionServer,
-  GQL_CONNECTION_INIT,
-  GQL_START,
-  GQL_STOP,
-  GQL_CONNECTION_TERMINATE,
-} from "graphyne-ws";
+import { startSubscriptionServer } from "graphyne-ws";
 
 startSubscriptionServer({
   onGraphyneWebSocketConnection: (connection) => {
     // called after the connection is init and the websocket server sends GQL_CONNECTION_ACK
-    connection.on(GQL_CONNECTION_INIT, (connectionParams) => {
+    connection.on('connection_init', (connectionParams) => {
       // optional parameters that the client specifies in connectionParams
     });
 
     // called after a subscription operation is started
-    connection.on(GQL_START, (id, payload) => {
+    connection.on('subscription_start', (id, payload) => {
       // id is the GraphQL operation ID
       // payload is the GQL payload with `query`, `variables`, and `operationName`.
     });
 
     // called after the operation is stopped
-    connection.on(GQL_STOP, (id) => {
+    connection.on('subscription_stop', (id) => {
       // id is the GraphQL operation ID that was stopped
     });
 
     // called after fulfilling client request for the connection to be terminated
-    connection.on(GQL_CONNECTION_TERMINATE, () => {
+    connection.on('connection_terminate', () => {
       // This event has no argument
     });
   },

--- a/packages/graphyne-ws/src/graphyneWebsocket.ts
+++ b/packages/graphyne-ws/src/graphyneWebsocket.ts
@@ -43,7 +43,7 @@ interface InitContext {
   request: IncomingMessage;
 }
 
-interface GraphyneWSOptions extends WebSocket.ServerOptions {
+export interface GraphyneWSOptions extends WebSocket.ServerOptions {
   context?: ContextFn;
   graphyne: GraphyneCore;
   onGraphyneWebSocketConnection?: (
@@ -55,7 +55,7 @@ type ContextFn =
   | Record<string, any>
   | ((initContext: InitContext) => Record<string, any>);
 
-interface GraphyneWebSocketConnection {
+export interface GraphyneWebSocketConnection {
   on(
     event: typeof GQL_CONNECTION_INIT,
     listener: (connectionParams: ConnectionParams) => void
@@ -72,7 +72,7 @@ interface GraphyneWebSocketConnection {
   emit(event: typeof GQL_CONNECTION_TERMINATE): boolean;
 }
 
-class GraphyneWebSocketConnection extends EventEmitter {
+export class GraphyneWebSocketConnection extends EventEmitter {
   private graphyne: GraphyneCore;
   public socket: WebSocket;
   private request: IncomingMessage;

--- a/packages/graphyne-ws/src/graphyneWebsocket.ts
+++ b/packages/graphyne-ws/src/graphyneWebsocket.ts
@@ -57,19 +57,19 @@ type ContextFn =
 
 export interface GraphyneWebSocketConnection {
   on(
-    event: typeof GQL_CONNECTION_INIT,
+    event: 'connection_init',
     listener: (connectionParams: ConnectionParams) => void
   ): this;
-  emit(event: typeof GQL_CONNECTION_INIT, payload: ConnectionParams): boolean;
+  emit(event: 'connection_init', payload: ConnectionParams): boolean;
   on(
-    event: typeof GQL_START,
+    event: 'subscription_start',
     listener: (id: string, payload: QueryBody) => void
   ): this;
-  emit(event: typeof GQL_START, id: string, payload: QueryBody): boolean;
-  on(event: typeof GQL_STOP, listener: (id: string) => void): this;
-  emit(event: typeof GQL_STOP, id: string): boolean;
-  on(event: typeof GQL_CONNECTION_TERMINATE, listener: () => void): this;
-  emit(event: typeof GQL_CONNECTION_TERMINATE): boolean;
+  emit(event: 'subscription_start', id: string, payload: QueryBody): boolean;
+  on(event: 'subscription_stop', listener: (id: string) => void): this;
+  emit(event: 'subscription_stop', id: string): boolean;
+  on(event: 'connection_terminate', listener: () => void): this;
+  emit(event: 'connection_terminate'): boolean;
 }
 
 export class GraphyneWebSocketConnection extends EventEmitter {
@@ -135,7 +135,7 @@ export class GraphyneWebSocketConnection extends EventEmitter {
         throw new GraphQLError('Prohibited connection!');
       this.sendMessage(GQL_CONNECTION_ACK);
       // Emit
-      this.emit(GQL_CONNECTION_INIT, data.payload as ConnectionParams);
+      this.emit('connection_init', data.payload as ConnectionParams);
     } catch (err) {
       this.sendMessage(GQL_CONNECTION_ERROR, data.id, {
         errors: [err],
@@ -195,7 +195,7 @@ export class GraphyneWebSocketConnection extends EventEmitter {
     this.operations.set(data.id, executionIterable);
 
     // Emit
-    this.emit(GQL_START, data.id, data.payload);
+    this.emit('subscription_start', data.id, data.payload);
 
     await forAwaitEach(executionIterable as any, (result: ExecutionResult) => {
       this.sendMessage(GQL_DATA, data.id, result);
@@ -218,7 +218,7 @@ export class GraphyneWebSocketConnection extends EventEmitter {
     if (!removingOperation) return;
     removingOperation.return?.();
     // Emit
-    this.emit(GQL_STOP, opId);
+    this.emit('subscription_stop', opId);
     this.operations.delete(opId);
   }
 
@@ -229,7 +229,7 @@ export class GraphyneWebSocketConnection extends EventEmitter {
       // Close connection after sending error message
       this.socket.close(1011);
       // Emit
-      this.emit(GQL_CONNECTION_TERMINATE);
+      this.emit('connection_terminate');
     }, 10);
   }
 

--- a/packages/graphyne-ws/src/index.ts
+++ b/packages/graphyne-ws/src/index.ts
@@ -1,1 +1,2 @@
 export { startSubscriptionServer } from './graphyneWebsocket';
+export * from './messageTypes';

--- a/packages/graphyne-ws/tests/graphyneWebsocket.spec.ts
+++ b/packages/graphyne-ws/tests/graphyneWebsocket.spec.ts
@@ -81,18 +81,21 @@ async function startServer(
 }
 
 describe('graphyne-ws', () => {
-  describe('startSubscriptionServer', () => {
-    it('accepts onGraphyneWebSocketConnection that is called with the GraphyneWebSocketConnection instance', (done) => {
-      const onGraphyneWebSocketConnection = (connection) => {
-        if (connection instanceof GraphyneWebSocketConnection) done();
+  it('onGraphyneWebSocketConnection', () => {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+      const { client, server } = await startServer({
+        onGraphyneWebSocketConnection,
+      });
+      function onGraphyneWebSocketConnection(connection) {
+        client.end();
+        server.close();
+        if (connection instanceof GraphyneWebSocketConnection) resolve();
         else
-          done(
-            new Error(
-              'onGraphyneWebSocketConnection is not called with GraphyneWebSocketConnection instance'
-            )
+          reject(
+            'onGraphyneWebSocketConnection is not called with GraphyneWebSocketConnection instance'
           );
-      };
-      startServer({ onGraphyneWebSocketConnection });
+      }
     });
   });
 


### PR DESCRIPTION
This PR adds a new option value `onGraphyneWebSocketConnection` which is a function to be called every time a `GraphyneWebSocketConnection` is created.

`GraphyneWebSocketConnection` is now an event emitter, which emit several events of Client->Server message after finished processing them. (Experimental)

See the README or TypeScript definition to learn more.