### PR TITLE
Always format GraphQL errors

### DIFF
--- a/packages/graphyne-server/README.md
+++ b/packages/graphyne-server/README.md
@@ -74,7 +74,6 @@ The function returns a never-rejected promise of the execution result, which is 
 
 **Warning:**
 
-- `errors` is not formatted using `options.formatError`. (A future version may provide a flag to do so)
 - `options.context` does not run here. You need to supply the context object to `contextValue`.
 
 ## Framework-specific integration

--- a/packages/graphyne-worker/README.md
+++ b/packages/graphyne-worker/README.md
@@ -105,7 +105,6 @@ The function returns a never-rejected promise of the execution result, which is 
 
 **Warning:**
 
-- `errors` is not formatted using `options.formatError`. (A future version may provide a flag to do so)
 - `options.context` does not run here. You need to supply the context object to `contextValue`.
 
 ## Contributing


### PR DESCRIPTION
This PR adds formatting of GraphQL errors when calling `graphyne#graphql` function