### PR TITLE
Report certain HTTP errors as string with content-type=text/plain

### DIFF
--- a/packages/graphyne-core/src/core.ts
+++ b/packages/graphyne-core/src/core.ts
@@ -126,7 +126,7 @@ export class Graphyne {
       obj: ExecutionResult | string,
       stringify = JSON.stringify,
       headers: Record<string, string> = typeof obj === 'string'
-        ? {}
+        ? { 'content-type': 'text/plain' }
         : { 'content-type': 'application/json' }
     ) =>
       cb({

--- a/packages/graphyne-core/src/core.ts
+++ b/packages/graphyne-core/src/core.ts
@@ -126,7 +126,7 @@ export class Graphyne {
       obj: ExecutionResult | string,
       stringify = JSON.stringify,
       headers: Record<string, string> = typeof obj === 'string'
-        ? { 'content-type': 'text/html; charset=utf-8' }
+        ? {}
         : { 'content-type': 'application/json' }
     ) =>
       cb({

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -1,13 +1,8 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { GraphQLSchema, GraphQLArgs } from 'graphql';
 import { strict as assert, deepStrictEqual } from 'assert';
-import {
-  Graphyne,
-  Config,
-  QueryBody,
-  QueryCache,
-  FormattedExecutionResult,
-} from '../src';
+import { Graphyne, QueryBody, FormattedExecutionResult } from '../src';
+import { Config, QueryCache } from '../src/types';
 import { Lru } from 'tiny-lru';
 
 const schema = makeExecutableSchema({
@@ -165,7 +160,8 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       { context: {} },
       {
         status: 400,
-        body: '{"errors":[{"message":"Must provide query string."}]}',
+        body: 'Must provide query string.',
+        headers: { 'content-type': 'text/html; charset=utf-8' },
       }
     );
   });
@@ -177,8 +173,8 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       },
       {
         status: 405,
-        body:
-          '{"errors":[{"message":"Operation mutation cannot be performed via a GET request"}]}',
+        body: 'Operation mutation cannot be performed via a GET request.',
+        headers: { 'content-type': 'text/html; charset=utf-8' },
       }
     );
   });
@@ -190,8 +186,8 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       },
       {
         status: 405,
-        body:
-          '{"errors":[{"message":"GraphQL only supports GET and POST requests."}]}',
+        body: 'GraphQL only supports GET and POST requests.',
+        headers: { 'content-type': 'text/html; charset=utf-8' },
       }
     );
   });

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -161,7 +161,7 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       {
         status: 400,
         body: 'Must provide query string.',
-        headers: {},
+        headers: { 'content-type': 'text/plain' },
       }
     );
   });
@@ -174,7 +174,7 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       {
         status: 405,
         body: 'Operation mutation cannot be performed via a GET request.',
-        headers: {},
+        headers: { 'content-type': 'text/plain' },
       }
     );
   });
@@ -187,7 +187,7 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       {
         status: 405,
         body: 'GraphQL only supports GET and POST requests.',
-        headers: {},
+        headers: { 'content-type': 'text/plain' },
       }
     );
   });

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -161,7 +161,7 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       {
         status: 400,
         body: 'Must provide query string.',
-        headers: { 'content-type': 'text/html; charset=utf-8' },
+        headers: {},
       }
     );
   });
@@ -174,7 +174,7 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       {
         status: 405,
         body: 'Operation mutation cannot be performed via a GET request.',
-        headers: { 'content-type': 'text/html; charset=utf-8' },
+        headers: {},
       }
     );
   });
@@ -187,7 +187,7 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       {
         status: 405,
         body: 'GraphQL only supports GET and POST requests.',
-        headers: { 'content-type': 'text/html; charset=utf-8' },
+        headers: {},
       }
     );
   });

--- a/packages/graphyne-worker/src/handler.ts
+++ b/packages/graphyne-worker/src/handler.ts
@@ -35,14 +35,10 @@ export async function handleRequest(
       try {
         body = parseBodyByContentType(await request.text(), oCtype);
       } catch (err) {
-        err.status = 400;
-        return new Response(
-          JSON.stringify(graphyne.formatExecutionResult({ errors: [err] })),
-          {
-            status: 400,
-            headers: { 'content-type': 'application/json' },
-          }
-        );
+        return new Response(err.message, {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        });
       }
     }
   }

--- a/packages/graphyne-worker/tests/worker.spec.ts
+++ b/packages/graphyne-worker/tests/worker.spec.ts
@@ -105,7 +105,8 @@ describe('graphyne-worker: handleRequest', () => {
         },
         {
           status: 400,
-          body: `{"errors":[{"message":"Must provide query string."}]}`,
+          // Because body is not parsed, query string cannot be read
+          body: `Must provide query string.`,
         }
       );
     });
@@ -116,7 +117,7 @@ describe('graphyne-worker: handleRequest', () => {
       '/graphql',
       {},
       {
-        body: `{"errors":[{"message":"Must provide query string."}]}`,
+        body: `Must provide query string.`,
         status: 400,
       }
     );


### PR DESCRIPTION
Right now, `graphyne-worker` and `graphyne-server` reports error like 'query string not provided' or 'method not allowed' in a GraphQL response format.

This does not make sense. This PR changes it to be reported as string with content-type=text/plain