### PR TITLE
Refactor

### DIFF
--- a/packages/graphyne-core/src/core.ts
+++ b/packages/graphyne-core/src/core.ts
@@ -54,7 +54,8 @@ export class Graphyne {
     query: string,
     operationName?: string | null
   ): QueryCache | ExecutionResult {
-    const cached = this.lru.get(query);
+    const key = query + (operationName ? `:${operationName}` : '');
+    const cached = this.lru.get(key);
 
     if (cached) {
       return cached;
@@ -95,13 +96,11 @@ export class Graphyne {
 
       // Cache the compiled query
       // TODO: We are not caching multi document query right now
-      if (this.lru && !operationName) {
-        this.lru.set(query, {
-          document,
-          jit,
-          operation,
-        });
-      }
+      this.lru.set(key, {
+        document,
+        jit,
+        operation,
+      });
 
       return { operation, jit, document };
     }

--- a/packages/graphyne-core/src/index.ts
+++ b/packages/graphyne-core/src/index.ts
@@ -8,3 +8,4 @@ export {
   TContext,
 } from './types';
 export { parseBodyByContentType, getGraphQLParams } from './utils';
+export { runHttpQuery } from './runHttpQuery';

--- a/packages/graphyne-core/src/runHttpQuery.ts
+++ b/packages/graphyne-core/src/runHttpQuery.ts
@@ -1,0 +1,66 @@
+import { Graphyne } from './core';
+import { ValueOrPromise, HttpQueryRequest, HttpQueryResponse } from './types';
+import flatstr from 'flatstr';
+import { ExecutionResult } from 'graphql';
+
+function createResponse(
+  graphyne: Graphyne,
+  code: number,
+  obj: ExecutionResult | string,
+  stringify = JSON.stringify,
+  headers: Record<string, string> = typeof obj === 'string'
+    ? { 'content-type': 'text/plain' }
+    : { 'content-type': 'application/json' }
+): HttpQueryResponse {
+  return {
+    body:
+      typeof obj === 'string'
+        ? obj
+        : flatstr(stringify(graphyne.formatExecutionResult(obj))),
+    status: code,
+    headers,
+  };
+}
+
+export function runHttpQuery(
+  graphyne: Graphyne,
+  { query, variables, operationName, context, httpMethod }: HttpQueryRequest
+): ValueOrPromise<HttpQueryResponse> {
+  if (!query) {
+    return createResponse(graphyne, 400, 'Must provide query string.');
+  }
+
+  const cachedOrResult = graphyne.getCachedGQL(query, operationName);
+
+  if (!('document' in cachedOrResult)) {
+    return createResponse(graphyne, 400, cachedOrResult);
+  }
+
+  const { document, operation, jit } = cachedOrResult;
+
+  if (httpMethod !== 'POST' && httpMethod !== 'GET')
+    return createResponse(
+      graphyne,
+      405,
+      `GraphQL only supports GET and POST requests.`
+    );
+  if (httpMethod === 'GET' && operation !== 'query')
+    return createResponse(
+      graphyne,
+      405,
+      `Operation ${operation} cannot be performed via a GET request.`
+    );
+
+  const result = graphyne.execute({
+    jit,
+    document: document,
+    contextValue: context,
+    variableValues: variables,
+  });
+
+  return 'then' in result
+    ? result.then((resolvedResult) =>
+        createResponse(graphyne, 200, resolvedResult, jit.stringify)
+      )
+    : createResponse(graphyne, 200, result, jit.stringify);
+}

--- a/packages/graphyne-core/src/types.ts
+++ b/packages/graphyne-core/src/types.ts
@@ -36,7 +36,7 @@ export interface HttpQueryResponse {
 export interface QueryCache {
   operation: string;
   document: DocumentNode;
-  compiledQuery: CompiledQuery;
+  jit: CompiledQuery;
 }
 
 // Can be replaced with `FormattedExecutionResult` from 5.3.0

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -383,7 +383,7 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
     });
     const lru: Lru<QueryCache> = (graphyne as any).lru;
     lru.set('{ helloWorld }', {
-      compiledQuery: {
+      jit: {
         query: () => ({ data: { cached: true } }),
         stringify: JSON.stringify,
       },

--- a/packages/graphyne-core/tests/core.spec.ts
+++ b/packages/graphyne-core/tests/core.spec.ts
@@ -1,7 +1,12 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { GraphQLSchema, GraphQLArgs } from 'graphql';
 import { strict as assert, deepStrictEqual } from 'assert';
-import { Graphyne, GraphQLParams, FormattedExecutionResult } from '../src';
+import {
+  Graphyne,
+  GraphQLParams,
+  FormattedExecutionResult,
+  runHttpQuery,
+} from '../src';
 import { Config, QueryCache } from '../src/types';
 import { Lru } from 'tiny-lru';
 
@@ -62,7 +67,7 @@ describe('graphyne-core: Graphyne', () => {
   });
 });
 
-describe('graphyne-core: Graphyne#runHttpQuery', () => {
+describe('graphyne-core: runHttpQuery', () => {
   type ExpectedBodyFn = (str: string) => void;
 
   function testHttp(
@@ -365,15 +370,10 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       schema,
     });
     const lru: Lru<QueryCache> = (graphyne as any).lru;
-    await new Promise((resolve) => {
-      graphyne.runHttpQuery(
-        {
-          query: '{ helloWorld }',
-          httpMethod: 'GET',
-          context: {},
-        },
-        resolve
-      );
+    await runHttpQuery(graphyne, {
+      query: '{ helloWorld }',
+      httpMethod: 'GET',
+      context: {},
     });
     assert(lru.has('{ helloWorld }'));
   });
@@ -390,15 +390,10 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       operation: 'query',
       document: '' as any,
     });
-    const { body } = await new Promise((resolve) => {
-      graphyne.runHttpQuery(
-        {
-          query: '{ helloWorld }',
-          httpMethod: 'GET',
-          context: {},
-        },
-        resolve
-      );
+    const { body } = await runHttpQuery(graphyne, {
+      query: '{ helloWorld }',
+      httpMethod: 'GET',
+      context: {},
     });
     assert.deepStrictEqual(body, JSON.stringify({ data: { cached: true } }));
   });
@@ -407,15 +402,10 @@ describe('graphyne-core: Graphyne#runHttpQuery', () => {
       schema,
     });
     const lru: Lru<QueryCache> = (graphyne as any).lru;
-    await new Promise((resolve) => {
-      graphyne.runHttpQuery(
-        {
-          query: '{ watt }',
-          httpMethod: 'GET',
-          context: {},
-        },
-        resolve
-      );
+    await runHttpQuery(graphyne, {
+      query: '{ watt }',
+      httpMethod: 'GET',
+      context: {},
     });
     assert(lru.has('{ watt }') !== true);
   });

--- a/packages/graphyne-ws/src/connection.ts
+++ b/packages/graphyne-ws/src/connection.ts
@@ -4,6 +4,7 @@ import {
   Graphyne,
   FormattedExecutionResult,
   TContext,
+  ValueOrPromise,
 } from 'graphyne-core';
 import * as WebSocket from 'ws';
 import { isAsyncIterable, forAwaitEach, createAsyncIterator } from 'iterall';
@@ -51,7 +52,8 @@ export interface SubscriptionConnection {
 
 export class SubscriptionConnection extends EventEmitter {
   private operations: Map<string, AsyncIterator<ExecutionResult>> = new Map();
-  contextPromise: Promise<TContext>;
+  // contextPromise because GQL_START may run right after GQL_CONNECTION_INIT
+  contextPromise: ValueOrPromise<TContext> = {};
   constructor(
     public socket: WebSocket,
     public request: IncomingMessage,
@@ -59,10 +61,9 @@ export class SubscriptionConnection extends EventEmitter {
     private options: GraphyneWSOptions
   ) {
     super();
-    this.contextPromise = Promise.resolve({});
   }
 
-  async handleMessage(message: string) {
+  handleMessage(message: string) {
     let data: OperationMessage;
     try {
       data = JSON.parse(message);
@@ -87,7 +88,7 @@ export class SubscriptionConnection extends EventEmitter {
     }
   }
 
-  async handleConnectionInit(data: OperationMessage) {
+  handleConnectionInit(data: OperationMessage) {
     // https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_init
     const initContext: InitContext = {
       request: this.request,
@@ -97,11 +98,10 @@ export class SubscriptionConnection extends EventEmitter {
     try {
       // resolve context
       if (this.options.context) {
-        this.contextPromise = Promise.resolve(
+        this.contextPromise =
           typeof this.options.context === 'function'
             ? this.options.context(initContext)
-            : this.options.context
-        );
+            : this.options.context;
       }
       this.sendMessage(GQL_CONNECTION_ACK);
       // Emit

--- a/packages/graphyne-ws/src/connection.ts
+++ b/packages/graphyne-ws/src/connection.ts
@@ -124,11 +124,10 @@ export class SubscriptionConnection extends EventEmitter {
       return this.sendError(data.id, new Error('Must provide query string.'));
     }
 
-    const {
-      document,
-      compiledQuery,
-      operation,
-    } = this.graphyne.getCompiledQuery(query, operationName);
+    const { document, jit, operation } = this.graphyne.getCachedGQL(
+      query,
+      operationName
+    );
 
     const context = await this.contextPromise;
     const executionResult = await this.graphyne[
@@ -138,7 +137,7 @@ export class SubscriptionConnection extends EventEmitter {
       contextValue: context,
       variableValues: variables,
       operationName,
-      compiledQuery,
+      jit,
     });
 
     const executionIterable = isAsyncIterable(executionResult)

--- a/packages/graphyne-ws/tests/ws.spec.ts
+++ b/packages/graphyne-ws/tests/ws.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../src';
 import { GraphyneWSOptions } from '../src/types';
 import { SubscriptionConnection } from '../src/connection';
-import { Graphyne } from '../../graphyne-core/src';
+import { Graphyne, runHttpQuery } from '../../graphyne-core/src';
 import { Config as GraphyneConfig } from '../../graphyne-core/src/types';
 import { parseBody } from '../../graphyne-server/src/http/parseBody';
 import WebSocket from 'ws';
@@ -85,17 +85,14 @@ async function startServer(
   const graphyne = new Graphyne({ schema, ...graphyneOpts });
   const server = createServer((req, res) => {
     parseBody(req, async (err, body) => {
-      graphyne.runHttpQuery(
-        {
-          query: body.query,
-          variables: body.variables,
-          operationName: body.operationName,
-          context: {},
-          httpMethod: req.method as string,
-        },
-        (result) =>
-          res.writeHead(result.status, result.headers).end(result.body)
-      );
+      const result = await runHttpQuery(graphyne, {
+        query: body.query,
+        variables: body.variables,
+        operationName: body.operationName,
+        context: {},
+        httpMethod: req.method as string,
+      });
+      res.writeHead(result.status, result.headers).end(result.body);
     });
   });
   const wss = new WebSocket.Server({ server });


### PR DESCRIPTION
- `getCompiledQuery` becomes `getCachedGQL`, which now has clearer return value (either `QueryCache` or `ExecutionResult`)
- seperate `runHttpQuery` from `Graphyne`
- tiny fixes